### PR TITLE
added `tol` argument to `rps_probs()`

### DIFF
--- a/R/helper_checks.R
+++ b/R/helper_checks.R
@@ -176,9 +176,9 @@ check_sizes_VecMat <- function(input, types) {
     reference_formats <- sapply(types, function(x) {
       switch(
         x,
-        vec = "vector[1:n]",
-        mat = "matrix[1:n, 1:m]",
-        scl = "scalar[1]"
+        vector = "vector[1:n]",
+        matrix = "matrix[1:n, 1:m]",
+        scalar = "scalar[1]"
       )
     })
     

--- a/R/helper_checks.R
+++ b/R/helper_checks.R
@@ -147,28 +147,45 @@ checkMatrix <- function(input) {
   }
 }
 
+is_scalar <- function(x) {
+  is.vector(x) && identical(length(x), 1L)
+}
+
 check_sizes_VecMat <- function(input, types) {
-  stopifnot(all(types %in% c("vec", "mat")))
+  stopifnot(all(types %in% c("vector", "matrix", "scalar")))
   stopifnot(identical(length(input), length(types)))
   
-  input_isvector <- sapply(input[types == "vec"], is.vector)
-  input_ismatrix <- sapply(input[types == "mat"], is.matrix)
-  input_dim1 <- sapply(input, function(x) {
+  input_matches_types <- 
+    all(sapply(input[types == "vector"], is.vector)) &&
+    all(sapply(input[types == "matrix"], is.matrix)) &&
+    all(sapply(input[types == "scalar"], is_scalar))
+  
+  input_dim1 <- sapply(input[types %in% c("vector", "matrix")], function(x) {
     if (is.vector(x)) length(x) else dim(x)[1L]
   })
-  input_dim2 <- sapply(input[types == "mat"], function(x) {
+  input_dim2 <- sapply(input[types == "matrix"], function(x) {
     if (is.matrix(x)) dim(x)[2L]
   })
+  input_dims_match <- c(
+    identical(length(unique(input_dim1)), 1L),
+    if ("matrix" %in% types) identical(length(unique(input_dim2)), 1L)
+  )
   
-  if (!all(input_isvector) ||
-      !all(input_ismatrix) ||
-      !identical(length(unique(input_dim1)), 1L) ||
-      !identical(length(unique(input_dim2)), 1L)) {
+  if (!input_matches_types || !all(input_dims_match)) {
     
-    reference_formats <- ifelse(types == "vec", "vector[1:n]", "matrix[1:n, 1:m]")
+    reference_formats <- sapply(types, function(x) {
+      switch(
+        x,
+        vec = "vector[1:n]",
+        mat = "matrix[1:n, 1:m]",
+        scl = "scalar[1]"
+      )
+    })
     
     input_formats <- sapply(input, function(x) {
-      if (is.vector(x)) {
+      if (is_scalar(x)) {
+        "scalar[1]"
+      } else if (is.vector(x)) {
         sprintf("vector[1:%i]", length(x))
       } else if (is.matrix(x)) {
         sprintf("matrix[1:%i, 1:%i]", dim(x)[1L], dim(x)[2L])

--- a/R/rps.R
+++ b/R/rps.R
@@ -1,7 +1,8 @@
 #' Ranked Probability Score
 #' @description Computes the Ranked Probability Score (RPS) for a given vector or matrix of probabilities.
 #' @param y vector of realizations, taking integer values between 1 and K. For the RPS, outcomes have an ordinal interpretation only (see details).
-#' @param x vector or matrix (depending on \code{y}; see details) of probabilities
+#' @param x vector or matrix (depending on \code{y}; see details) of probabilities.
+#' @param tol non-negative numeric value specifying the allowed deviation from 1 of the total (row-wise) probability in \code{x}.
 #' @details 
 #' The RPS interprets the outcome variable as ordinal. That is, different outcome values can be ranked (e.g., \code{y=1} is smaller than \code{y=2}), but their numerical difference has no meaningful interpretation. 
 #' For simplicity, the outcome \code{y} is coded as an integer here, with \code{y = 1} indicating the smallest possible realization and \code{y = K} indicating the largest possible realization. 
@@ -27,14 +28,16 @@
 #' Krueger, F. and L. Pavlova (2024): `Quantifying Subjective
 #' Uncertainty in Survey Expectations', International Journal of Forecasting 40, 796-810, \doi{10.1016/j.ijforecast.2023.06.001}.
 #' @export
-rps_probs <- function(y, x){
-  input <- list(y = y, x = x)
-  checkNumeric(input)
+rps_probs <- function(y, x, tol = .Machine$double.eps){
+  input <- list(y = y, x = x, tol = tol)
+  checkNumeric(input, infinite_exception = "tol")
   
-  if (identical(length(y), 1L) && is.vector(x)) {
-    check_p0(y, x)
+  if (is_scalar(y)) {
+    check_sizes_VecMat(input, c(y = "scalar", x = "vector", tol = "scalar"))
+    check_p0(y, x, tol)
     rps0(y = y, x = x)
   } else {
+    check_sizes_VecMat(input, c(y = "vector", x = "matrix", tol = "scalar"))
     check_p2(input)
     sapply(seq_along(y),
            function(i) rps0(y = y[i], x = x[i, ]))
@@ -47,17 +50,23 @@ rps0 <- function(y, x){
   sum((Px - Py)^2) # sum of Brier scores over categories
 }
 
-check_p0 <- function(y, x){
+check_p0 <- function(y, x, tol){
   msg <- character(0)
   K <- length(x)
   if (K < 2){
-    msg <- c(msg, "Number of outcome categories K must be >= 2")
+    msg <- c(msg, "Number of outcome categories K must be >= 2.")
   }
   if (isFALSE(y %in% 1:K)){
-    msg <- c(msg, "Unexpected input for y (should be integer between 1 and K, where K is the number of categories)")
-  } 
-  if (isTRUE(any(x < 0)) || isTRUE(abs(sum(x) - 1) > .Machine$double.eps)){
-    msg <- c(msg, "Probabilities in x must be nonnegative and sum to one")
+    msg <- c(msg, "Unexpected input for 'y' (should be integer between 1 and K, where K is the number of categories).")
+  }
+  if (isTRUE(any(x < 0))) {
+    msg <- c(msg, "Probabilities in 'x' must be nonnegative.")
+  }
+  if (isTRUE(any(tol < 0))) {
+    msg <- c(msg, "Parameter 'tol' must be nonnegative.")
+  }
+  if (isTRUE(abs(sum(x) - 1) > tol)){
+    msg <- c(msg, "Probabilities in 'x' should sum to one (increase 'tol' if a deviation is intended).")
   }
   if (length(msg) > 0){
     stop(paste(msg, collapse = "\n"))
@@ -65,8 +74,8 @@ check_p0 <- function(y, x){
 }
 
 check_p2 <- function(input){
-  check_sizes_VecMat(input, c(y = "vec", x = "mat"))
   sapply(seq_along(input$y),
          function(i) check_p0(y = input$y[i], 
-                              x = input$x[i, ]))
+                              x = input$x[i, ],
+                              tol = input$tol))
 }

--- a/man/rps_probs.Rd
+++ b/man/rps_probs.Rd
@@ -4,12 +4,14 @@
 \alias{rps_probs}
 \title{Ranked Probability Score}
 \usage{
-rps_probs(y, x)
+rps_probs(y, x, tol = .Machine$double.eps)
 }
 \arguments{
 \item{y}{vector of realizations, taking integer values between 1 and K. For the RPS, outcomes have an ordinal interpretation only (see details).}
 
-\item{x}{vector or matrix (depending on \code{y}; see details) of probabilities}
+\item{x}{vector or matrix (depending on \code{y}; see details) of probabilities.}
+
+\item{tol}{non-negative numeric value specifying the allowed deviation from 1 of the total (row-wise) probability in \code{x}.}
 }
 \description{
 Computes the Ranked Probability Score (RPS) for a given vector or matrix of probabilities.

--- a/tests/testthat/test-rps.R
+++ b/tests/testthat/test-rps.R
@@ -5,7 +5,14 @@ test_that("function works as expected", {
   expect_error(rps_probs(y = 5, x = c(.1, .5, .5)))
   expect_error(rps_probs(y = 3.1, x = c(.1, .5, .4)))
   expect_error(rps_probs(y = c(2, 3), x = c(.1, .5, .5)))
+  expect_error(rps_probs(y = 1, x = c(.5, .5 - 1e-15)))
+  expect_error(rps_probs(y = 1, x = c(.5, .5), tol = c(.1, .1)))
+  expect_error(rps_probs(y = 1, x = c(.5, .5), tol = NA))
   # Correct inputs
+  expect_gt(
+    rps_probs(y = 1, x = c(.5, .5 - 1e-7), tol = 1e-6),
+    rps_probs(y = 1, x = c(.5, .5))
+  )
   y <- 5
   x1 <- c(rep(0, y-1), 1)
   x2 <- rep(1/y, y)


### PR DESCRIPTION
Fixes #63 

- adds a tolerance argument to `rps_probs()` and updates documentation
- allows `check_sizes_VecMat()` to also check vectors of length 1 (i.e., scalars)
- adds further unit tests for `rps_probs()`